### PR TITLE
check for master then develop or abort

### DIFF
--- a/master_status.rb
+++ b/master_status.rb
@@ -17,15 +17,18 @@ result        = JSON.parse(res.body)
 projects = {}
 
 result.each do |k|
-  repo = "#{k['username']}/#{k['reponame']}"
-  status = "#{k['branches']['master']['recent_builds'][0]['status']}"
-  projects["#{repo}"] = {
-    url:    "https://circleci.com/gh/#{repo}",
-    status: "#{status}"
-  }
-end
 
-# p projects
+  branch = k['branches']['master'] ? 'master' : 'develop'
+  repo = "#{k['username']}/#{k['reponame']}"
+
+  if k['branches'][branch]
+    status = "#{k['branches'][branch]['recent_builds'][0]['status']}"
+    projects["#{repo}"] = {
+      url:    "https://circleci.com/gh/#{repo}",
+      status: "#{status}"
+    }
+  end
+end
 
 xmlstring = "<?xml version=\"1.0\"?>\n<items>\n"
 


### PR DESCRIPTION
I noticed the `cis` command fails if any repo lacks a master branch. And a bunch of mine have develop as the main branch. 

This just falls back to develop if master doesn't exist as well as not failing if the repo has neither master nor develop. 

I don't think this is the nicest fix. You may want to fix this slightly differently so feel free to take what you will or ignore. I've made an issue for it either way. It would just be nice to have some fall back if the status breaks. 
#2

Rad workflow otherwise. 
