### PR TITLE
Add support for opening the new pipeline page

### DIFF
--- a/pipeline_search.rb
+++ b/pipeline_search.rb
@@ -1,0 +1,40 @@
+require 'json'
+
+thequery  = ARGV[0]
+json_file = '/var/tmp/circleci.json'
+
+begin
+  result = open(json_file) do |io|
+    JSON.load(io)
+  end
+rescue
+  puts "#{json_file} not found."
+  exit
+end
+
+pipelines = {}
+
+result.each do |k|
+  project_slug = "#{k['vcs_type']}/#{k['username']}/#{k['reponame']}"
+  pipelines["#{project_slug}"] = {
+    url:    "https://app.circleci.com/#{project_slug}/pipelines"
+  }
+end
+
+xmlstring = "<?xml version=\"1.0\"?>\n<items>\n"
+
+pipelines.each_with_index do |(k, v), i|
+  if k.match(%r{[^\/]*#{thequery}[^\/]*$}i)
+    thisxmlstring = "\t<item uid=\"#{i}\" autocomplete=\"#{k}\" arg=\"#{v[:url]}\" valid=\"YES\">
+    <title>#{k}</title>
+    <subtitle>#{v[:url]}</subtitle>
+    </item>\n"
+    xmlstring += thisxmlstring
+  else
+    next
+  end
+end
+
+xmlstring += '</items>'
+
+puts xmlstring


### PR DESCRIPTION
Slight modification of the `workflow_search` script to the new pipeline page for a project instead. I've been using `cip` as the prefix. Also works with VCSs other than Github, like BitBucket.