### PR TITLE
Fix typo

### DIFF
--- a/update_cache.rb
+++ b/update_cache.rb
@@ -12,7 +12,7 @@ res           = https.request(req)
 
 if res.code == '200'
   File.write('/var/tmp/circleci.json', res.body)
-  puts 'Success. Update CIrcleci Project URLs Cache.'
+  puts 'Success. Updated CircleCI Project URLs Cache.'
 else
   puts "#{res.message}"
 end


### PR DESCRIPTION
Hi! This PR simply fixes a typo.

There's another typo in the `info.plist` file, that is not committed in the repo:

> CircleCI Master Blanch Build Status

Should be:

> CircleCI Master Branch Build Status